### PR TITLE
Prevent warnings during upgrades

### DIFF
--- a/debian/scripts/iobroker_startup.sh
+++ b/debian/scripts/iobroker_startup.sh
@@ -499,7 +499,7 @@ shut_down() {
   echo "Recived termination signal (SIGTERM)."
   echo "Shutting down ioBroker..."
   pid=$(ps -ef | awk '/[j]s.controller/{print $2}')
-  kill -SIGTERM "$pid"
+  [[ -n "$pid" ]] && kill -SIGTERM "$pid"
   exit
 }
 


### PR DESCRIPTION
It would probably even better to use `pkill -u iobroker iobroker.js-con` (yep, shortened name as per procfs) similar to what `maintenance.sh` does. Not sure why manual searching and killing was implemented here, but this fixes the warning if there was no matching process found.