### PR TITLE
Rewrite maintenance.sh

### DIFF
--- a/debian/scripts/maintenance.sh
+++ b/debian/scripts/maintenance.sh
@@ -1,234 +1,210 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-############################
-##### default settings #####
-############################
+# Bash strict mode.
+set -euo pipefail
 
-autoconfirm=no              # could be set to true by commandline option
-killbyname=no               # could be set to true by commandline option / undocumented, only for use with backitup restore scripts
+autoconfirm=    # Can be set to 'yes' by command line option.
+killbyname=     # Can be set to 'yes' by command line option /
+                # undocumented, only for use with backitup restore scripts.
+healthcheck=/opt/scripts/.docker_config/.healthcheck
 
-####################################
-##### declaration of functions #####
-####################################
-
-# display help text
 display_help() {
-  echo "This script is build to manage your ioBroker container!"
+  echo 'This script manages your ioBroker container.'
   echo ''
-  echo "Usage: maintenance [ COMMAND ] [ OPTION ]"
-  echo "       maint [ COMMAND ] [ OPTION ]"
-  echo "       m [ COMMAND ] [ OPTION ]"
+  echo "Usage: ${BASH_SOURCE[0]} COMMAND [OPTION]"
   echo ''
-  echo "COMMANDS"
-  echo "------------------"
-  echo "       status     > reports the current state of maintenance mode"
-  echo "       on         > switches mantenance mode ON"
-  echo "       off        > switches mantenance mode OFF and shuts down or restarts container"
-  echo "       upgrade    > will put container to maintenance mode and upgrade ioBroker"
-  echo "       help       > shows this help"
+  echo 'COMMANDS'
+  echo '------------------'
+  echo '       status     > reports the current state of maintenance mode'
+  echo '       on         > switches mantenance mode ON'
+  echo '       off        > switches mantenance mode OFF and stops or restarts the container'
+  echo '       upgrade    > puts the container to maintenance mode and upgrades ioBroker'
+  echo '       help       > shows this help'
   echo ''
-  echo "OPTIONS"
-  echo "------------------"
-  echo "       -y|--yes   > confirms the used command without asking"
-  echo "       -h|--help  > shows this help"
+  echo 'OPTIONS'
+  echo '------------------'
+  echo '       -y|--yes   > confirms the used command without asking'
+  echo '       -h|--help  > shows this help'
   echo ''
-  exit 0
 }
 
-# checking maintenance mode status
-check_status() {
-  if [ $(cat /opt/scripts/.docker_config/.healthcheck) == 'maintenance' ]
-  then
+maintenance_enabled() {
+  [[ -f "$healthcheck" && "$(cat "$healthcheck")" == maintenance ]]
+}
+
+maintenance_status() {
+  if maintenance_enabled; then
     echo 'Maintenance mode is turned ON.'
-  elif [ $(cat /opt/scripts/.docker_config/.healthcheck) != 'maintenance' ]
-  then
+  else
     echo 'Maintenance mode is turned OFF.'
   fi
 }
 
-# turn maintenance mode ON
-switch_on() {
-  if [ $(cat /opt/scripts/.docker_config/.healthcheck) != 'maintenance' ] && [ "$killbyname" == "yes" ] # maintenance mode OFF / killbyname = yes  / undocumented, only for use with backitup restore scripts
-  then
+enable_maintenance() {
+  if maintenance_enabled; then
+    echo 'Maintenance mode is already turned ON.'
+    return
+  fi
+
+  if [[ "$killbyname" == yes ]]; then
+    # Undocumented, only for use with backitup restore scripts.
+
     echo 'This command will activate maintenance mode and stop js-controller.'
     echo 'Activating maintenance mode...'
-    echo "maintenance" > /opt/scripts/.docker_config/.healthcheck
-    sleep 1
-    echo 'Done.'
+    echo 'maintenance' > "$healthcheck"
     echo 'Stopping ioBroker...'
-    pkill -u iobroker -f iobroker.js-controller
-    sleep 1
+    stop_and_wait 60 -u iobroker -f iobroker.js-controller
     echo 'Done.'
-    exit 0
-  elif [ $(cat /opt/scripts/.docker_config/.healthcheck) != 'maintenance' ] && [ "$autoconfirm" == "no" ] # maintenance mode OFF / autoconfirm = no
-  then
-    echo 'You are now going to stop ioBroker and activating maintenance mode for this container.'
-    read -p 'Do you want to continue [yes/no]? ' A
-    if [ "$A" == "y" ] || [ "$A" == "Y" ] || [ "$A" == "yes" ]
-    then
-      echo 'Activating maintenance mode...'
-      echo "maintenance" > /opt/scripts/.docker_config/.healthcheck
-      sleep 1
-      echo 'Done.'
-      echo 'Stopping ioBroker...'
-      pkill -u iobroker
-      sleep 1
-      echo 'Done.'
-      exit 0
-    else
-    exit 0
-    fi
-  elif [ $(cat /opt/scripts/.docker_config/.healthcheck) != 'maintenance' ] && [ "$autoconfirm" == "yes" ] # maintenance mode OFF / autoconfirm = yes
-  then
-    echo 'You are now going to stop ioBroker and activating maintenance mode for this container.'
-    echo 'This command was already confirmed by -y or --yes option.'
-    echo 'Activating maintenance mode...'
-    echo "maintenance" > /opt/scripts/.docker_config/.healthcheck
-    sleep 1
-    echo 'Done.'
-    echo 'Stopping ioBroker...'
-    pkill -u iobroker
-    sleep 1
-    echo 'Done.'
-    exit 0
-  else
-    echo 'Maintenance mode is already turned ON.'
+    return
   fi
+
+  echo 'You are now going to stop ioBroker and activate maintenance mode for this container.'
+
+  if [[ "$autoconfirm" != yes ]]; then
+    local reply
+
+    read -rp 'Do you want to continue [yes/no]? ' reply
+    if [[ "$reply" == y || "$reply" == Y || "$reply" == yes ]]; then
+      : # Pass.
+    else
+      return 1
+    fi
+  else
+    echo 'This command was already confirmed by the -y or --yes option.'
+  fi
+
+  echo 'Activating maintenance mode...'
+  echo 'maintenance' > "$healthcheck"
+  echo 'Stopping ioBroker...'
+  stop_and_wait 60 -u iobroker
 }
 
-# turn maintenance mode OFF
-switch_off() {
-  if [ $(cat /opt/scripts/.docker_config/.healthcheck) == 'maintenance' ] && [ "$autoconfirm" == "no" ] # maintenance mode ON / autoconfirm = no
-  then
-    echo 'You are now going to deactivate maintenance mode for this container.'
-    echo 'Depending on the restart policy, your container will be stopped or restarted immediately.'
-    read -p 'Do you want to continue [yes/no]? ' A
-    if [ "$A" == "y" ] || [ "$A" == "Y" ] || [ "$A" == "yes" ]
-    then
-      echo 'Deactivating maintenance mode and forcing container to stop or restart...'
-      echo "stopping" > /opt/scripts/.docker_config/.healthcheck
-      pkill -u root
-      echo 'Done.'
-      exit 0
-    else
-      exit 0
-    fi
-  elif [ $(cat /opt/scripts/.docker_config/.healthcheck) == 'maintenance' ] && [ "$autoconfirm" == "yes" ] # maintenance mode ON / autoconfirm = yes
-  then
-    echo 'You are now going to deactivate maintenance mode for this container.'
-    echo 'Depending on the restart policy, your container will be stopped or restarted immediately.'
-    echo 'This command was already confirmed by -y or --yes option.'
-    echo 'Deactivating maintenance mode and forcing container to stop or restart...'
-    echo "stopping" > /opt/scripts/.docker_config/.healthcheck
-    pkill -u root
-    echo 'Done.'
-    exit 0
-  else
+disable_maintenance() {
+  if ! maintenance_enabled; then
     echo 'Maintenance mode is already turned OFF.'
+    return
   fi
+
+  echo 'You are now going to deactivate maintenance mode for this container.'
+  echo 'Depending on the restart policy, your container will be stopped or restarted immediately.'
+
+  if [[ "$autoconfirm" != yes ]]; then
+    local reply
+
+    read -rp 'Do you want to continue [yes/no]? ' reply
+    if [[ "$reply" == y || "$reply" == Y || "$reply" == yes ]]; then
+      : # Pass.
+    else
+      return 1
+    fi
+  else
+    echo 'This command was already confirmed by the -y or --yes option.'
+  fi
+
+  echo 'Deactivating maintenance mode and forcing container to stop or restart...'
+  echo 'stopping' > "$healthcheck"
+  stop_and_wait 60 -u root
 }
 
-# upgrade js-controller
-upgrade() {
+upgrade_jscontroller() {
   echo 'You are now going to upgrade your js-controller.'
   echo 'As this will change data in /opt/iobroker, make sure you have a backup!'
-  echo 'During the upgrade process the container will automatically switch into maintenance mode and stop ioBroker.'
-  echo 'Depending of the restart policy, your container will be stopped or restarted automatically after the upgrade.'
+  echo 'During the upgrade process, the container will automatically switch into maintenance mode and stop ioBroker.'
+  echo 'Depending on the restart policy, your container will be stopped or restarted automatically after the upgrade.'
 
-  if [ "$autoconfirm" == "no" ]
-  then
-    read -p 'Do you want to continue [yes/no]? ' A
-    if [ "$A" == "y" ] || [ "$A" == "Y" ] || [ "$A" == "yes" ]
-    then
-      : # Continue.
+  if [[ "$autoconfirm" != yes ]]; then
+    local reply
+
+    read -rp 'Do you want to continue [yes/no]? ' reply
+    if [[ "$reply" == y || "$reply" == Y || "$reply" == yes ]]; then
+      : # Pass.
     else
-      exit 0
+      return 1
     fi
-  elif [ "$autoconfirm" == "yes" ]
-  then
-    echo 'This command was already confirmed by -y or --yes option.'
+  else
+    echo 'This command was already confirmed by the -y or --yes option.'
   fi
-  if [ $(cat /opt/scripts/.docker_config/.healthcheck) != 'maintenance' ]
-  then
-    echo 'Activating maintenance mode...'
-    echo "maintenance" > /opt/scripts/.docker_config/.healthcheck
-    sleep 1
-    echo 'Done.'  
-    echo 'Stopping ioBroker...'
-    pkill -u iobroker
-    sleep 5
-    echo 'Done.'
+
+  if ! maintenance_enabled > /dev/null; then
+    autoconfirm=yes
+    enable_maintenance
   fi
+
   echo 'Upgrading js-controller...'
   iobroker update
-  sleep 1
   iobroker upgrade self
-  sleep 1
   echo 'Done.'
-  echo 'Container will be stopped or restarted in 5 seconds...'
-  sleep 5
-  echo "stopping" > /opt/scripts/.docker_config/.healthcheck
-  pkill -u root
-  exit 0
+
+  echo 'Container will be stopped or restarted...'
+  echo 'stopping' > "$healthcheck"
+  stop_and_wait 60 -u root
 }
 
-########################################
-##### parsing commands and options #####
-########################################
+stop_and_wait() {
+  local status timeout
 
-# reading all arguments and putting them in reverse
-reverse=
-for i in "$@"; do
-  reverse="$i $reverse"
-done
+  timeout="${1:?Need timeout in seconds}"
+  shift
 
-# checking the arguments
-for i in $reverse; do
-  case $i in
+  timeout="$(date --date='now + 60 sec' +%s)"
+  pkill "$@"
+  status=$?
+  if (( status >= 2 )); then # Syntax error or fatal error.
+    return 1
+  fi
+
+  if (( status == 1 )); then # No processes matched or could be signalled.
+    return
+  fi
+
+  # pgrep exits with status 1 when there are no matches, i.e. everyone exited.
+  while pgrep "$@" > /dev/null; (( $? != 1 )); do
+    if (($(date +%s) > timeout)); then
+      printf 'timed out\n'
+      return 1
+    fi
+
+    printf '.'
+    sleep 0.5
+  done
+
+  printf '\n'
+}
+
+# Default command to run unless another was given.
+run=(display_help)
+for arg in "$@"; do
+  case $arg in
     help|-h|--help)
-      display_help        # calling function to display help text
-      break
+      run=(display_help)
       ;;
     status)
-      check_status        # calling function to check maintenance mode status
-      break
+      run=(maintenance_status)
       ;;
     on)
-      switch_on           # calling function to switch maintenance mode on
-      break
+      run=(enable_maintenance)
       ;;
     off)
-      switch_off          # calling function to switch maintenance mode off
-      break
+      run=(disable_maintenance)
       ;;
     upgrade)
-      upgrade             # calling function to upgrade js-controller
-      break
+      run=(upgrade_jscontroller)
       ;;
     -y|--yes)
-      autoconfirm=yes     # setting autoconfrm option to "yes"
-      shift
+      autoconfirm=yes
       ;;
     -kbn|--killbyname)
-      killbyname=yes     # setting killbyname option to "yes"
-      shift
+      killbyname=yes
       ;;
-    -a=*|--argument=*)    # dummy exaple for parsing option with value
-      ARGUMENT="${i#*=}"
-      shift
-      ;;
-    --)                   # End of all options.
-      shift
+    --)
       break
       ;;
-    -?*|?*)
-      echo 'WARN: Unknown parameter. Please try again or see help (-h|--help).'
-      break
-      ;;
-    *)                    # Default case: No more options, so break out of the loop.
-      break
+    *)
+      >&2 echo "Unknown parameter: $arg"
+      >&2 echo 'Please try again or see help (help|-h|--help).'
+      exit 1
       ;;
   esac
 done
 
-exit 0
+"${run[@]}"


### PR DESCRIPTION
Ich hab nach unserer Diskussion in #233 das `maintenance.sh`-Skript etwas umgeschrieben.

Dazu ein paar Anmerkungen:

* POSIX `[` und Bash `[[` zu `[[` vereinheitlicht
* Quoting aller Variablen
* [Bash Strict Mode](http://redsymbol.net/articles/unofficial-bash-strict-mode/) aktiviert, alle return codes `!= 0` müssen explizit mit `if` behandelt werden oder das Skript bricht ab
* Shellcheck-Warnings behoben (hauptsächlich `read` ohne `-r` betreffend)
* `maint` und `m` existiert bei mir nicht, alle möglichen Aufrufe in der Hilfe durch `BASH_SOURCE` ersetzt
* Command Line Parsing verbessert, kein reverse notwendig
* diverse Duplikationen entfernt, in Funktionen oder Variablen ausgelagert
* `if`-Nesting verringert
* `pkill` und `pgrep` wie in [#233](https://github.com/buanet/ioBroker.docker/issues/233#issuecomment-1036310659) besprochen mit Timeout versehen

Jetzt gibt es bei mir tatsächlich ein Problem mit `pgrep` nach `pkill`:

* Ich nutze den [adb-Adapter](https://github.com/om2804/ioBroker.adb)
* Dieser startet eine `adb` Executable als `iobroker`-User
* `adb` reagiert nicht auf `SIGTERM`
* Bei mir rennt das ioBroker-Beenden deshalb immer in den Timeout

Mögliche Lösungen:

1. Special Case für adb schaffen und Instanzen dieses Adapaters beim Aktivieren der Maintenance beenden (vielleicht geht das per `iob`.
2. Nach dem Timeout noch ein `SIGKILL` nachschieben.

Vielleicht hat @Apollon77 hierfür eine gute Idee.

Da es gestern ein Update des js-controllers gab, so sieht der Output aus (adb hatte ich vorher beendet). Nach `Stopping ioBroker...` gibt's eine Zeile mit ein paar Punkten, dort wurde gewartet dass alle Prozesse beendet wurden. Pro Punkt 500ms == 8 Sekunden, also über dem aktuell hartcodierten Timeout von 5 Sekunden.

```sh
root@iobroker:/opt/scripts# ./maintenance.sh upgrade
You are now going to upgrade your js-controller.
As this will change data in /opt/iobroker, make sure you have a backup!
During the upgrade process, the container will automatically switch into maintenance mode and stop ioBroker.
Depending on the restart policy, your container will be stopped or restarted automatically after the upgrade.
Do you want to continue [yes/no]? yes
You are now going to stop ioBroker and activate maintenance mode for this container.
This command was already confirmed by the -y or --yes option.
Activating maintenance mode...
Stopping ioBroker...
................
Upgrading js-controller...
^NUsed repository: beta
Adapter    "accuweather"  : 1.2.4    , installed 1.2.4
Adapter    "adb"          : 0.0.5    , installed 0.0.5
...
Update js-controller from @4.0.7 to @4.0.8
Stopped Objects DB
Stopped States DB
NPM version: 6.14.16
Installing iobroker.js-controller@4.0.8... (System call)

> iobroker.js-controller@4.0.8 preinstall /opt/iobroker/node_modules/iobroker.js-controller
> node lib/preinstallCheck.js

NPM version: 6.14.16

> iobroker.js-controller@4.0.8 install /opt/iobroker/node_modules/iobroker.js-controller
> node iobroker.js setup first

Successfully migrated 8459 objects to Redis Sets
object _design/system updated

{
  "defaultPrivate": "-----BEGIN RSA PRIVATE KEY-----\r\nMIIEpQIBAAKCAQEA6Ir5IFyKBHYDIGrfxtZ9JfZt9SFrW9SVMTTKrCMVhdr7F0XO\r\nINtAJnRwzZpxzSSSj7abfZwlg9kiK3aY",
  "defaultPublic": "-----BEGIN CERTIFICATE-----\r\nMIIDfjCCAmagAwIBAgIJD8rZcscFrXvcMA0GCSqGSIb3DQEBCwUAMD4xETAPBgNV\r\nBAMTCGlvYnJva2VyMRYwFAYDV"
}
Update certificate defaultPrivate
The object "system.certificates" was updated successfully.
Update certificate defaultPublic
The object "system.certificates" was updated successfully.
+ iobroker.js-controller@4.0.8
added 1 package from 2 contributors, removed 34 packages and updated 25 packages in 95.976s
^[[B
119 packages are looking for funding
  run `npm fund` for details

Done.
Container will be stopped or restarted...
Terminated
root@iobroker:/opt/scripts# %

pi@raspberrypi ~
$
```