### PR TITLE
wait for 10 seconds after sending SIGTERM

### DIFF
--- a/debian/scripts/iobroker_startup.sh
+++ b/debian/scripts/iobroker_startup.sh
@@ -499,6 +499,8 @@ shut_down() {
   echo "Recived termination signal (SIGTERM)."
   echo "Shutting down ioBroker..."
   pkill -SIGTERM -u iobroker -f iobroker.js-controller
+  timeout 10 tail --pid=`pgrep -f iobroker.js-controller` -f /dev/null
+  echo "ioBroker stopped"
   exit
 }
 


### PR DESCRIPTION
It's better to wait until the main ioBorker controller process is finished with it's shutdown.
If we don't wait for the clean shutdown, the adapter hm-rpc can not disconnect from the ccu gateway and is not working after a container restart.
See:
https://github.com/ioBroker/ioBroker.hm-rpc/issues/595


