### PR TITLE
Changed the description on Docker Hub, sorted list of backup files 

### DIFF
--- a/.github/workflows/update-docker-readme.yml
+++ b/.github/workflows/update-docker-readme.yml
@@ -20,7 +20,7 @@ jobs:
         username: ${{ secrets.DOCKER_USER }}
         password: ${{ secrets.DOCKER_PASS }}
         repository: buanet/iobroker
-        short-description: Official Docker image for ioBroker based on Debian Bullseye slim 
+        short-description: Official Docker image for ioBroker based on Debian Bookworm slim 
         readme-filepath: ./docs/README_docker_hub_buanet.md
 
     - name: Update Docker Hub Readme (iobroker)
@@ -29,5 +29,5 @@ jobs:
         username: ${{ secrets.DOCKER_USER_IOB }}
         password: ${{ secrets.DOCKER_PASS_IOB }}
         repository: iobroker/iobroker
-        short-description: Official Docker image for ioBroker based on Debian Bullseye slim
+        short-description: Official Docker image for ioBroker based on Debian Bookworm slim
         readme-filepath: ./docs/README_docker_hub_iobroker.md

--- a/debian12/scripts/maintenance.sh
+++ b/debian12/scripts/maintenance.sh
@@ -245,7 +245,7 @@ restore_iobroker() {
 
   # list backup files
   backup_dir="/opt/iobroker/backups"
-  backup_files=($(find $backup_dir -type f))
+  backup_files=($(find $backup_dir -type f | sort))
   backup_count=${#backup_files[@]}
 
   if [[ $backup_count -eq 0 ]]; then


### PR DESCRIPTION
The description on Docker Hub was previously labeled as 'bullseye' and has now been updated to 'bookworm'.